### PR TITLE
Add HTML template editor for question rendering

### DIFF
--- a/app/Extractor.php
+++ b/app/Extractor.php
@@ -213,13 +213,12 @@ final class Extractor
             }
 
             $type = $this->decideType($qHtml, $answers);
-            $template = 'Q1';
 
             $idx++;
             $questions[] = [
                 'index'     => $idx,
                 'type'      => $type,
-                'template'  => $template,
+                'template'  => $type,
                 'statement' => [
                     'html'   => $qHtml,
                     'text'   => $stmtText,

--- a/app/Templates.php
+++ b/app/Templates.php
@@ -1,20 +1,243 @@
 <?php
 declare(strict_types=1);
 
-final class Templates {
-    public static function renderQuestion(array $q): string {
+final class Templates
+{
+    private const TEMPLATE_DIR = TEMPLATES_PATH . '/question_templates';
+
+    private const BASE_TEMPLATE = <<<HTML
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+  {{ answers_list }}
+</div>
+HTML;
+
+    public static function renderQuestion(array $q): string
+    {
         $answers = [];
-        foreach ($q['answers'] as $a) {
-            $answers[] = preg_replace('~^<li\\b~', '<li class="ans"', $a['html']);
+        foreach ($q['answers'] ?? [] as $a) {
+            $answers[] = preg_replace('~^<li\\b~', '<li class="ans"', $a['html'] ?? '');
         }
-        $imgs = self::images($q['statement']['images']);
-        $qText = '<span class="qnum">'.$q['index'].'. </span>'.$q['statement']['html'];
-        return '<div class="qblock"><div class="qtext">'.$qText.'</div>'.$imgs.'<ol class="answers" type="a">'.implode('', $answers).'</ol></div>';
+
+        $answersItems = implode('', $answers);
+        $answersList  = $answersItems === '' ? '' : '<ol class="answers" type="a">' . $answersItems . '</ol>';
+        $images       = self::images($q['statement']['images'] ?? []);
+
+        $templateName = $q['template'] ?? ($q['type'] ?? 'T1');
+        $template     = self::loadTemplateContent($templateName, $q['type'] ?? null);
+
+        $map = self::buildReplacementMap($q, $templateName, $images, $answersList, $answersItems);
+
+        return strtr($template, $map);
     }
 
-    public static function images(array $srcs): string {
-        if (!$srcs) return '';
-        $tags = array_map(fn($s)=>'<img src="'.htmlspecialchars($s, ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8').'" alt="img" class="qimg">', $srcs);
-        return '<div class="qimgs">'.implode('', $tags).'</div>';
+    public static function images(array $srcs): string
+    {
+        if ($srcs === []) {
+            return '';
+        }
+
+        $tags = array_map(
+            static fn($s) => '<img src="' . htmlspecialchars((string) $s, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '" alt="img" class="qimg">',
+            $srcs
+        );
+
+        return '<div class="qimgs">' . implode('', $tags) . '</div>';
+    }
+
+    public static function availableTypes(): array
+    {
+        return [
+            'T1' => [
+                'label'       => 'Choix unique',
+                'description' => 'Question à choix simple avec une seule réponse correcte.',
+            ],
+            'T2' => [
+                'label'       => 'Choix multiple',
+                'description' => 'Question permettant plusieurs réponses.',
+            ],
+            'T3' => [
+                'label'       => 'Réponse libre',
+                'description' => 'Question sans propositions (réponse à rédiger).',
+            ],
+            'T4' => [
+                'label'       => 'Vrai / Faux',
+                'description' => 'Question binaire avec deux propositions.',
+            ],
+        ];
+    }
+
+    public static function placeholderDocs(?string $type = null): array
+    {
+        $docs = [
+            [
+                'tag'         => '{{ template_name }}',
+                'description' => 'Nom du template utilisé (utile pour du debug).',
+            ],
+            [
+                'tag'         => '{{ question_type }}',
+                'description' => 'Type détecté (T1, T2, T3, T4…).',
+            ],
+            [
+                'tag'         => '{{ question_index }}',
+                'description' => 'Numéro de la question.',
+            ],
+            [
+                'tag'         => '{{ statement_html }}',
+                'description' => 'Énoncé complet au format HTML.',
+            ],
+            [
+                'tag'         => '{{ statement_text }}',
+                'description' => 'Version texte de l’énoncé (sans balises).',
+            ],
+            [
+                'tag'         => '{{ images }}',
+                'description' => 'Bloc `<div>` contenant toutes les images (vide si aucune).',
+            ],
+            [
+                'tag'         => '{{ answers_list }}',
+                'description' => 'Liste `<ol>` déjà prête avec les propositions.',
+                'types'       => ['T1', 'T2', 'T4'],
+            ],
+            [
+                'tag'         => '{{ answers_items }}',
+                'description' => 'Propositions seules (suite de `<li>`).',
+                'types'       => ['T1', 'T2', 'T4'],
+            ],
+            [
+                'tag'         => '{{ answers_count }}',
+                'description' => 'Nombre de propositions détectées.',
+            ],
+            [
+                'tag'         => '{{ answers_letters }}',
+                'description' => 'Liste des lettres associées aux réponses (A, B, C…).',
+                'types'       => ['T1', 'T2', 'T4'],
+            ],
+        ];
+
+        if ($type === null) {
+            return $docs;
+        }
+
+        $type = self::sanitizeName($type);
+
+        return array_values(array_filter(
+            $docs,
+            static function (array $entry) use ($type): bool {
+                if (!isset($entry['types'])) {
+                    return true;
+                }
+                return in_array($type, $entry['types'], true);
+            }
+        ));
+    }
+
+    public static function normalizeName(?string $name): string
+    {
+        return self::sanitizeName($name);
+    }
+
+    public static function loadTemplateContent(string $name, ?string $fallbackType = null): string
+    {
+        $clean = self::sanitizeName($name);
+        $path  = self::templatePath($clean);
+
+        if (is_readable($path)) {
+            $content = file_get_contents($path);
+            if ($content !== false) {
+                return $content;
+            }
+        }
+
+        $fallback = $fallbackType ? self::sanitizeName($fallbackType) : $clean;
+
+        return self::defaultTemplate($fallback);
+    }
+
+    public static function saveTemplateContent(string $name, string $content): void
+    {
+        $clean = self::sanitizeName($name);
+        $types = self::availableTypes();
+        if (!array_key_exists($clean, $types)) {
+            throw new InvalidArgumentException('Type de template inconnu.');
+        }
+
+        self::ensureTemplateDir();
+        $path = self::templatePath($clean);
+
+        if (@file_put_contents($path, $content) === false) {
+            throw new RuntimeException('Impossible d\'écrire le template sur le disque.');
+        }
+    }
+
+    private static function buildReplacementMap(
+        array $q,
+        string $templateName,
+        string $images,
+        string $answersList,
+        string $answersItems
+    ): array {
+        $index     = (string) ($q['index'] ?? '');
+        $type      = (string) ($q['type'] ?? '');
+        $statement = $q['statement'] ?? [];
+        $answers   = $q['answers'] ?? [];
+
+        $letters = [];
+        $count   = count($answers);
+        for ($i = 0; $i < $count; $i++) {
+            $letters[] = chr(65 + ($i % 26));
+        }
+
+        return [
+            '{{ template_name }}'   => htmlspecialchars($templateName, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            '{{ question_type }}'   => htmlspecialchars($type, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            '{{ question_index }}'  => htmlspecialchars($index, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            '{{ statement_html }}'  => $statement['html'] ?? '',
+            '{{ statement_text }}'  => htmlspecialchars((string) ($statement['text'] ?? ''), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            '{{ images }}'          => $images,
+            '{{ answers_list }}'    => $answersList,
+            '{{ answers_items }}'   => $answersItems,
+            '{{ answers_count }}'   => (string) $count,
+            '{{ answers_letters }}' => $letters === [] ? '' : implode(', ', $letters),
+        ];
+    }
+
+    private static function sanitizeName(?string $name): string
+    {
+        $sanitized = strtoupper(preg_replace('~[^A-Za-z0-9_-]+~', '', (string) $name));
+        if ($sanitized === 'Q1') {
+            $sanitized = 'T1';
+        }
+        if ($sanitized === '') {
+            $sanitized = 'T1';
+        }
+        return $sanitized;
+    }
+
+    private static function templatePath(string $name): string
+    {
+        return self::TEMPLATE_DIR . '/' . $name . '.html';
+    }
+
+    private static function ensureTemplateDir(): void
+    {
+        $dir = self::TEMPLATE_DIR;
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0775, true);
+        }
+    }
+
+    private static function defaultTemplate(string $name): string
+    {
+        return match ($name) {
+            'T3' => <<<HTML
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+</div>
+HTML,
+            default => self::BASE_TEMPLATE,
+        };
     }
 }

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -21,3 +21,19 @@ a{ color:var(--primary); text-decoration:none } .container{ max-width:1200px; ma
 .group{ padding:12px; border:1px solid var(--border); border-radius:12px; background:#fff; }
 .group.layout-horizontal .gqs{ display:flex; gap:16px; }
 .group.layout-vertical .gqs{ display:flex; flex-direction:column; gap:16px; }
+.text-muted{ color:var(--muted); }
+.text-muted.small{ font-size:12px; }
+.template-editor{ display:flex; flex-wrap:wrap; gap:16px; margin-top:16px; }
+.template-editor .editor-pane{ flex:2 1 620px; min-width:320px; display:flex; flex-direction:column; gap:12px; }
+.template-editor .docs-pane{ flex:1 1 260px; min-width:240px; background:rgba(148,163,184,0.08); border:1px solid var(--border); border-radius:12px; padding:16px; }
+.template-meta h4{ margin:0; }
+.template-meta p{ margin:4px 0 0; }
+.code-editor{ width:100%; height:520px; border:1px solid var(--border); border-radius:12px; overflow:hidden; }
+.template-toolbar select{ padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; }
+.placeholder-list{ list-style:none; padding:0; margin:12px 0 0; display:flex; flex-direction:column; gap:12px; }
+.placeholder-list li{ border:1px solid var(--border); border-radius:10px; padding:10px; background:#fff; }
+.placeholder-list code{ display:inline-block; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:12px; padding:2px 6px; border-radius:6px; background:rgba(37,99,235,0.08); color:#1d4ed8; }
+.placeholder-list p{ margin:8px 0 0; font-size:13px; color:var(--muted); }
+#templateStatus{ min-height:20px; }
+#templateStatus.success{ color:#16a34a; }
+#templateStatus.error{ color:#dc2626; }

--- a/public/index.php
+++ b/public/index.php
@@ -67,6 +67,38 @@ try {
             view('pages/editor.php', ['title'=>'Éditeur & Template']);
             break;
 
+        case 'template_editor':
+            $type = $_GET['type'] ?? 'T1';
+            view('pages/template_editor.php', [
+                'title' => 'Éditeur de template',
+                'type'  => $type,
+            ]);
+            break;
+
+        case 'load_template':
+            $type = $_GET['type'] ?? '';
+            $normalized = Templates::normalizeName($type);
+            $content = Templates::loadTemplateContent($normalized, $normalized);
+            $types = Templates::availableTypes();
+            $meta = $types[$normalized] ?? ['label'=>$normalized, 'description'=>''];
+            json_response([
+                'ok'           => true,
+                'type'         => $normalized,
+                'content'      => $content,
+                'label'        => $meta['label'] ?? $normalized,
+                'description'  => $meta['description'] ?? '',
+                'placeholders' => Templates::placeholderDocs($normalized),
+            ]);
+            break;
+
+        case 'save_template':
+            $payload = json_decode(file_get_contents('php://input'), true) ?? [];
+            $type = $payload['type'] ?? '';
+            $content = $payload['content'] ?? '';
+            Templates::saveTemplateContent($type, $content);
+            json_response(['ok'=>true]);
+            break;
+
         case 'save_groups':
             $payload = json_decode(file_get_contents('php://input'), true) ?? [];
             $_SESSION['groups'] = $payload['groups'] ?? [];

--- a/templates/pages/editor_inner.php
+++ b/templates/pages/editor_inner.php
@@ -3,6 +3,12 @@ $extract = $_SESSION['extract'] ?? ['questions'=>[]];
 $groups  = $_SESSION['groups'] ?? [];
 $blocks  = Grouper::build($extract['questions'], $groups);
 $meta    = $_SESSION['meta'] ?? ['title' => '', 'letter' => ''];
+$typesUsed = [];
+foreach ($extract['questions'] as $q) {
+  $t = $q['type'] ?? '';
+  if ($t !== '') $typesUsed[$t] = true;
+}
+$typesUsed = array_keys($typesUsed);
 ?>
 
 <h3>Paramètres du questionnaire</h3>
@@ -60,7 +66,10 @@ $meta    = $_SESSION['meta'] ?? ['title' => '', 'letter' => ''];
   <div class="card" style="flex:2; min-width:380px">
     <h4>Prévisualisation</h4>
     <div class="preview" id="preview">—</div>
-    <div class="row"><a class="btn" href="?action=export">Exporter (rendu final)</a></div>
+    <div class="row">
+      <a class="btn" href="?action=export">Exporter (rendu final)</a>
+      <button class="btn ghost" id="editTemplate" data-types='<?= htmlspecialchars(json_encode($typesUsed, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES), ENT_QUOTES) ?>'>Éditer les templates</button>
+    </div>
   </div>
 </div>
 <script>
@@ -143,4 +152,20 @@ async function previewAll(){
 
 renderTable();
 previewAll();
+
+const editBtn = document.getElementById('editTemplate');
+if (editBtn) {
+  const types = (() => {
+    try {
+      return JSON.parse(editBtn.dataset.types || '[]');
+    } catch (e) {
+      return [];
+    }
+  })();
+  editBtn.addEventListener('click', () => {
+    const targetType = types.length ? types[0] : 'T1';
+    const features = 'width=1100,height=800,menubar=no,toolbar=no,location=no';
+    window.open(`?action=template_editor&type=${encodeURIComponent(targetType)}`, '_blank', features);
+  });
+}
 </script>

--- a/templates/pages/template_editor.php
+++ b/templates/pages/template_editor.php
@@ -1,0 +1,1 @@
+<?php require __DIR__ . '/template_editor_inner.php'; ?>

--- a/templates/pages/template_editor_inner.php
+++ b/templates/pages/template_editor_inner.php
@@ -1,0 +1,157 @@
+<?php
+/** @var string $type */
+$types = Templates::availableTypes();
+$normalized = Templates::normalizeName($type ?? 'T1');
+if (!isset($types[$normalized])) {
+    $keys = array_keys($types);
+    $normalized = $keys[0] ?? 'T1';
+}
+$templateContent = Templates::loadTemplateContent($normalized, $normalized);
+$placeholders = Templates::placeholderDocs($normalized);
+$currentMeta = $types[$normalized] ?? ['label' => $normalized, 'description' => ''];
+?>
+
+<div class="template-header">
+  <div>
+    <h3>Éditeur de template de question</h3>
+    <p class="text-muted">Personnalisez la structure HTML utilisée lors du rendu des questions dans la prévisualisation et l'export.</p>
+  </div>
+</div>
+
+<div class="template-toolbar row" style="align-items:flex-end;">
+  <label class="template-select">
+    Type de question
+    <select id="templateType">
+      <?php foreach ($types as $code => $meta): ?>
+        <option value="<?= htmlspecialchars($code, ENT_QUOTES) ?>" <?= $code === $normalized ? 'selected' : '' ?>><?= htmlspecialchars($code . ' — ' . ($meta['label'] ?? $code), ENT_QUOTES) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </label>
+  <button class="btn primary" id="saveTemplate">Enregistrer le template</button>
+  <span id="templateStatus" class="text-muted"></span>
+</div>
+
+<div class="template-editor">
+  <div class="editor-pane">
+    <div class="template-meta">
+      <h4 id="templateTitle"><?= htmlspecialchars($normalized . ' — ' . ($currentMeta['label'] ?? $normalized), ENT_QUOTES) ?></h4>
+      <p id="templateDescription" class="text-muted"><?= htmlspecialchars($currentMeta['description'] ?? '', ENT_QUOTES) ?></p>
+    </div>
+    <div id="templateEditor" class="code-editor" aria-label="Éditeur de template"></div>
+  </div>
+  <aside class="docs-pane">
+    <h4>Balises disponibles</h4>
+    <p class="text-muted small">Ces balises seront remplacées automatiquement lors du rendu.</p>
+    <ul id="placeholderList" class="placeholder-list">
+      <?php foreach ($placeholders as $entry): ?>
+        <li>
+          <code><?= htmlspecialchars($entry['tag'] ?? '', ENT_QUOTES) ?></code>
+          <p><?= htmlspecialchars($entry['description'] ?? '', ENT_QUOTES) ?></p>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  </aside>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.23.4/ace.js" integrity="sha512-u4q7mDRu1qY07ZhE8LwQ2TWwPEBUacfjYLAQAHr53Tx5qr4uIX067OJHUz+2cmgJ8e6mpjqpQi9SgSdLD9gxXQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+(function(){
+  const initialContent = <?= json_encode($templateContent, JSON_UNESCAPED_UNICODE) ?>;
+  const initialPlaceholders = <?= json_encode($placeholders, JSON_UNESCAPED_UNICODE) ?>;
+  const metaByType = <?= json_encode($types, JSON_UNESCAPED_UNICODE) ?>;
+  const normalized = <?= json_encode($normalized, JSON_UNESCAPED_UNICODE) ?>;
+
+  function updatePlaceholderList(listEl, entries){
+    listEl.innerHTML = '';
+    if (!Array.isArray(entries) || entries.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'Aucune balise spécifique pour ce type.';
+      li.classList.add('text-muted');
+      listEl.appendChild(li);
+      return;
+    }
+    entries.forEach(entry => {
+      const li = document.createElement('li');
+      const code = document.createElement('code');
+      code.textContent = entry.tag || '';
+      const desc = document.createElement('p');
+      desc.textContent = entry.description || '';
+      li.appendChild(code);
+      li.appendChild(desc);
+      listEl.appendChild(li);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const typeSelect = document.getElementById('templateType');
+    const statusEl = document.getElementById('templateStatus');
+    const placeholderList = document.getElementById('placeholderList');
+    const titleEl = document.getElementById('templateTitle');
+    const descEl = document.getElementById('templateDescription');
+
+    if (typeof ace === 'undefined') {
+      statusEl.textContent = 'Ace Editor n\'a pas pu être chargé.';
+      statusEl.classList.add('error');
+      return;
+    }
+
+    const editor = ace.edit('templateEditor');
+    editor.setTheme('ace/theme/textmate');
+    editor.session.setMode('ace/mode/html');
+    editor.session.setUseWrapMode(true);
+    editor.setOptions({ fontSize: '14px', showPrintMargin: false });
+    editor.setValue(initialContent || '', -1);
+
+    updatePlaceholderList(placeholderList, initialPlaceholders);
+
+    function applyMeta(typeCode){
+      const meta = metaByType[typeCode] || { label: typeCode, description: '' };
+      titleEl.textContent = `${typeCode} — ${meta.label || typeCode}`;
+      descEl.textContent = meta.description || '';
+    }
+
+    applyMeta(normalized);
+
+    typeSelect.addEventListener('change', async () => {
+      const type = typeSelect.value;
+      statusEl.textContent = '';
+      statusEl.classList.remove('success', 'error');
+      try {
+        const res = await fetch(`?action=load_template&type=${encodeURIComponent(type)}`);
+        if (!res.ok) throw new Error('Chargement impossible');
+        const js = await res.json();
+        if (!js.ok) throw new Error(js.error || 'Erreur lors du chargement');
+        editor.setValue(js.content || '', -1);
+        updatePlaceholderList(placeholderList, js.placeholders || []);
+        applyMeta(js.type || type);
+      } catch (err) {
+        statusEl.textContent = err.message || 'Erreur inconnue';
+        statusEl.classList.add('error');
+      }
+    });
+
+    document.getElementById('saveTemplate').addEventListener('click', async () => {
+      const type = typeSelect.value;
+      statusEl.textContent = 'Enregistrement…';
+      statusEl.classList.remove('error', 'success');
+      try {
+        const res = await fetch('?action=save_template', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type, content: editor.getValue() })
+        });
+        const js = await res.json();
+        if (!res.ok || !js.ok) throw new Error(js.error || 'Erreur lors de la sauvegarde');
+        statusEl.textContent = 'Template enregistré.';
+        statusEl.classList.add('success');
+        if (window.opener && typeof window.opener.previewAll === 'function') {
+          window.opener.previewAll();
+        }
+      } catch (err) {
+        statusEl.textContent = err.message || 'Erreur inconnue';
+        statusEl.classList.add('error');
+      }
+    });
+  });
+})();
+</script>

--- a/templates/question_templates/T1.html
+++ b/templates/question_templates/T1.html
@@ -1,0 +1,5 @@
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+  {{ answers_list }}
+</div>

--- a/templates/question_templates/T2.html
+++ b/templates/question_templates/T2.html
@@ -1,0 +1,5 @@
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+  {{ answers_list }}
+</div>

--- a/templates/question_templates/T3.html
+++ b/templates/question_templates/T3.html
@@ -1,0 +1,4 @@
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+</div>

--- a/templates/question_templates/T4.html
+++ b/templates/question_templates/T4.html
@@ -1,0 +1,5 @@
+<div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  {{ images }}
+  {{ answers_list }}
+</div>


### PR DESCRIPTION
## Summary
- refactor template rendering to load per-type HTML files and expose placeholder documentation
- add backend routes and a highlighted editor page to manage question templates
- link the question editor to the template editor and refresh the preview after saves while updating styling

## Testing
- php -l app/Templates.php
- php -l public/index.php
- php -l templates/pages/template_editor_inner.php

------
https://chatgpt.com/codex/tasks/task_e_68e50247e790832ebc2d0f93a6346f9f