### PR TITLE
Add direct navigation to the template editor

### DIFF
--- a/templates/layout.php
+++ b/templates/layout.php
@@ -18,6 +18,7 @@
       <div>
         <a href="?action=home" class="btn">Accueil</a>
         <a href="?action=editor" class="btn">Éditeur</a>
+        <a href="?action=template_editor" class="btn">Templates</a>
         <a href="?action=export" class="btn">Exporter</a>
 		<a href="?action=convcsv" class="btn">QCM chatGPT</a>
 		<a href="?action=grille" class="btn primary">Grille</a>

--- a/templates/pages/editor_inner.php
+++ b/templates/pages/editor_inner.php
@@ -70,6 +70,7 @@ $typesUsed = array_keys($typesUsed);
       <a class="btn" href="?action=export">Exporter (rendu final)</a>
       <button class="btn ghost" id="editTemplate" data-types='<?= htmlspecialchars(json_encode($typesUsed, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES), ENT_QUOTES) ?>'>Éditer les templates</button>
     </div>
+    <p class="text-muted small">Le bouton «&nbsp;Éditer les templates&nbsp;» ouvre l’éditeur dans une nouvelle fenêtre. Vous pouvez également y accéder via le bouton «&nbsp;Templates&nbsp;» dans la barre supérieure.</p>
   </div>
 </div>
 <script>

--- a/templates/pages/home_inner.php
+++ b/templates/pages/home_inner.php
@@ -50,6 +50,10 @@
   <a class="btn" href="?action=editor">Ouvrir l’éditeur</a>
 </div>
 
+<h3>Éditeur de templates de questions</h3>
+<p class="text-muted">Utilisez cet éditeur pour personnaliser l’affichage HTML des différentes formes de questions (T1, T2, …). Il peut être ouvert à tout moment.</p>
+<a class="btn ghost" href="?action=template_editor" target="_blank">Ouvrir l’éditeur de templates</a>
+
 <h3>Debug</h3>
 <div class="toolbox">
   <a class="btn" href="?action=open_intermediate" target="_blank">Voir intermediate.html</a>


### PR DESCRIPTION
## Summary
- add a top navigation button that opens the template editor directly
- expose a dedicated section on the home page with guidance and a link to the template editor
- clarify in the editor page where to find the template editing window

## Testing
- php -l templates/layout.php
- php -l templates/pages/editor_inner.php
- php -l templates/pages/home_inner.php

------
https://chatgpt.com/codex/tasks/task_e_68e53ffa32b8832e9e00a6aa6d2cad2b