### PR TITLE
Handle missing grid module gracefully

### DIFF
--- a/app/GridModule.php
+++ b/app/GridModule.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+final class GridModuleUnavailableException extends RuntimeException {}
+
 /**
  * Classe de liaison avec le module de grilles de réponses.
  * Cette implémentation est un simple socle en attendant
@@ -22,6 +24,8 @@ final class GridModule {
      */
     public function generate(string $zipRoot, string $outputDir): array {
         // Le projet grille n'est pas encore intégré : on signale l'absence.
-        throw new RuntimeException('Module grille non installé dans ' . $this->moduleDir);
+        throw new GridModuleUnavailableException(
+            'Module grille indisponible. Installez-le dans ' . $this->moduleDir
+        );
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -142,7 +142,11 @@ try {
             if (!$root) throw new RuntimeException('Pas de lot en cours');
             $lot = Pipeline::workingLotDir();
             $grid = new GridModule();
-            $paths = $grid->generate($root, $lot);
+            try {
+                $paths = $grid->generate($root, $lot);
+            } catch (GridModuleUnavailableException $e) {
+                json_response(['ok'=>false, 'error'=>$e->getMessage()], 503);
+            }
             $_SESSION['grid_files'] = $paths;
             json_response(['ok'=>true, 'files'=>$paths]);
             break;


### PR DESCRIPTION
## Summary
- introduce a dedicated `GridModuleUnavailableException` to signal when the external grid module is absent
- update the `generate_grids` action to return a JSON error with HTTP 503 instead of crashing when the module is missing

## Testing
- php -l app/GridModule.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68e54201af38832eb6c04f57b423efa8