### PR TITLE
Fix PHP 7 compatibility for grid module

### DIFF
--- a/app/GridModule.php
+++ b/app/GridModule.php
@@ -9,7 +9,10 @@ final class GridModuleUnavailableException extends RuntimeException {}
  * l'intégration du projet "grille".
  */
 final class GridModule {
-    private string $moduleDir;
+    /**
+     * @var string
+     */
+    private $moduleDir;
 
     public function __construct(string $moduleDir = GRID_MODULE_PATH) {
         $this->moduleDir = $moduleDir;


### PR DESCRIPTION
## Summary
- replace the typed property in the grid module wrapper with a classic property declaration so it loads on PHP 7 installs
- document the property type to preserve intent

## Testing
- php -l app/GridModule.php

------
https://chatgpt.com/codex/tasks/task_e_68e545943958832eb80d9736c3f9b78e