### PR TITLE
Handle missing preview files with 404 responses

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -191,7 +191,12 @@ try {
 			
         case 'open_intermediate': {
             $file = $_SESSION['intermediate_html'] ?? null;
-            if (!$file || !is_readable($file)) throw new RuntimeException('intermediate.html introuvable');
+            if (!$file || !is_readable($file)) {
+                http_response_code(404);
+                header('Content-Type: text/plain; charset=utf-8');
+                echo "intermediate.html introuvable\n";
+                exit;
+            }
             $html = file_get_contents($file);
             // Réécrit les liens d'images pour passage via ?action=media&p=
             if ($html !== false) {
@@ -202,7 +207,12 @@ try {
 
         case 'open_export': {
             $file = $_SESSION['last_export'] ?? null;
-            if (!$file || !is_readable($file)) throw new RuntimeException('render.html introuvable');
+            if (!$file || !is_readable($file)) {
+                http_response_code(404);
+                header('Content-Type: text/plain; charset=utf-8');
+                echo "render.html introuvable\n";
+                exit;
+            }
             $html = file_get_contents($file);
             if ($html !== false) {
                 $html = rewrite_media_srcs($html);


### PR DESCRIPTION
## Summary
- return HTTP 404 with a plain-text explanation when intermediate or export preview files are missing
- keep successful preview responses unchanged while avoiding the global error handler

## Testing
- php -S 0.0.0.0:8000 -t public >/tmp/server.log 2>&1 &
- curl -s -D - http://127.0.0.1:8000/?action=open_intermediate
- curl -s -D - http://127.0.0.1:8000/?action=open_export
- pkill php

------
https://chatgpt.com/codex/tasks/task_e_68e5474c9330832eb4047468644c49c0