### PR TITLE
Fix default template helper for PHP 7 compatibility

### DIFF
--- a/app/Templates.php
+++ b/app/Templates.php
@@ -230,14 +230,16 @@ HTML;
 
     private static function defaultTemplate(string $name): string
     {
-        return match ($name) {
-            'T3' => <<<HTML
+        switch ($name) {
+            case 'T3':
+                return <<<HTML
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
   <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
   {{ images }}
 </div>
-HTML,
-            default => self::BASE_TEMPLATE,
-        };
+HTML;
+            default:
+                return self::BASE_TEMPLATE;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace the PHP 8 match expression in `Templates::defaultTemplate` with a switch statement
- restore compatibility with environments running PHP 7

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54d723100832e997eb101755b92aa