### PR TITLE
Add text-area fallback when Ace editor fails to load

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -29,6 +29,8 @@ a{ color:var(--primary); text-decoration:none } .container{ max-width:1200px; ma
 .template-meta h4{ margin:0; }
 .template-meta p{ margin:4px 0 0; }
 .code-editor{ width:100%; height:520px; border:1px solid var(--border); border-radius:12px; overflow:hidden; }
+.template-editor-fallback{ width:100%; height:520px; border:1px solid var(--border); border-radius:12px; padding:12px; font-family:ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size:14px; line-height:1.5; box-sizing:border-box; resize:vertical; background-color:#fff; color:var(--text); overflow:auto; }
+#templateStatus.warning{ color:#d97706; }
 .template-toolbar select{ padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; }
 .placeholder-list{ list-style:none; padding:0; margin:12px 0 0; display:flex; flex-direction:column; gap:12px; }
 .placeholder-list li{ border:1px solid var(--border); border-radius:10px; padding:10px; background:#fff; }


### PR DESCRIPTION
## Summary
- add a graceful fallback to a plain textarea when the Ace editor script is unavailable or fails to initialize
- reuse shared setters/getters for template content loading and saving so the UI keeps working in fallback mode
- style the fallback editor and introduce a warning status color to match the new messaging

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e54e94c3e4832eb3ae3cddffc1ff26