### PR TITLE
Ajoute un saut de ligne entre le numéro et l’énoncé des questions

### DIFF
--- a/app/Templates.php
+++ b/app/Templates.php
@@ -7,7 +7,7 @@ final class Templates
 
     private const BASE_TEMPLATE = <<<HTML
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
   {{ answers_list }}
 </div>
@@ -239,7 +239,7 @@ HTML;
             case 'T3':
                 return <<<HTML
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
 </div>
 HTML;

--- a/templates/question_templates/T1.html
+++ b/templates/question_templates/T1.html
@@ -1,5 +1,5 @@
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
   {{ answers_list }}
 </div>

--- a/templates/question_templates/T2.html
+++ b/templates/question_templates/T2.html
@@ -1,5 +1,5 @@
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
   {{ answers_list }}
 </div>

--- a/templates/question_templates/T3.html
+++ b/templates/question_templates/T3.html
@@ -1,4 +1,4 @@
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
 </div>

--- a/templates/question_templates/T4.html
+++ b/templates/question_templates/T4.html
@@ -1,5 +1,5 @@
 <div class="qblock" data-template="{{ template_name }}" data-type="{{ question_type }}">
-  <div class="qtext"><span class="qnum">{{ question_index }}. </span>{{ statement_html }}</div>
+  <div class="qtext"><span class="qnum">{{ question_index }}. </span><br>{{ statement_html }}</div>
   {{ images }}
   {{ answers_list }}
 </div>


### PR DESCRIPTION
## Summary
- insère un saut de ligne après le numéro de question dans tous les gabarits HTML
- aligne le modèle PHP par défaut sur la même structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5712a237c832e819e24826e049e1f