### PR TITLE
Ajout d’un bilan debug avec log brut et état des services

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -10,8 +10,33 @@ document.addEventListener('DOMContentLoaded', () => {
       const res = await fetch('?action=upload', { method:'POST', body:fd });
       const js = await res.json();
       if (!js.ok) return alert(js.error||'Erreur upload');
+      serviceStates.upload = true; updateServiceStatus();
       step('upload'); await scanDocx();
     });
+  }
+
+
+  const serviceStates = {
+    upload: false,
+    docx: false,
+    html: false,
+    extract: false,
+    log: false
+  };
+
+  function updateServiceStatus() {
+    const list = $('#service-status');
+    if (!list) return;
+    const entries = [
+      ['Upload', serviceStates.upload],
+      ['Scan DOCX', serviceStates.docx],
+      ['Conversion HTML', serviceStates.html],
+      ['Extraction', serviceStates.extract],
+      ['Log debug', serviceStates.log],
+    ];
+    list.innerHTML = entries
+      .map(([name, ok]) => `<li>${name}: <strong>${ok ? 'actif' : 'inactif'}</strong></li>`)
+      .join('');
   }
 
   async function scanDocx() {
@@ -20,6 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!js.ok) return alert(js.error||'Erreur scan');
     const list = $('#docx-list');
     list.innerHTML = `<div class="row" id="docx-items">` + js.docx.map(p=>`<label class="btn ghost"><input type="radio" name="docx" value="${p}" ${p===js.docx[0]?'checked':''}> ${p.split('/').pop()}</label>`).join('') + `</div>`;
+    serviceStates.docx = true; updateServiceStatus();
     step('docx');
   }
 
@@ -29,14 +55,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('?action=convert_html', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({docx: selected.value}) });
     const js = await res.json();
     if (!js.ok) return alert(js.error||'Erreur convert');
-    $('#html-path').textContent = js.file; step('html');
+    $('#html-path').textContent = js.file;
+    serviceStates.html = true; updateServiceStatus();
+    step('html');
   });
 
   $('#btn-extract')?.addEventListener('click', async ()=>{
     const res = await fetch('?action=extract');
     const js = await res.json();
     if (!js.ok) return alert(js.error||'Erreur extract');
-    renderExtract(js.extract); step('extract');
+    renderExtract(js.extract);
+    serviceStates.extract = true; updateServiceStatus();
+    step('extract');
   });
 
   function renderExtract(extract) {
@@ -51,11 +81,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   $('#btn-log')?.addEventListener('click', async ()=>{
     const res = await fetch('?action=debug_log'); const js = await res.json();
-    if (js.ok) $('#log').textContent = (js.log||[]).join('');
+    if (js.ok) {
+      const text = (js.log||[]).join('');
+      $('#log').textContent = text;
+      $('#raw-log').textContent = text || 'Aucun log brut disponible.';
+      serviceStates.log = true;
+      updateServiceStatus();
+    }
   });
   $('#btn-log-clear')?.addEventListener('click', async ()=>{
     const res = await fetch('?action=debug_log&clear=1'); const js = await res.json();
-    if (js.ok) $('#log').textContent = '';
+    if (js.ok) {
+      $('#log').textContent = '';
+      $('#raw-log').textContent = 'Aucun log brut chargé.';
+      serviceStates.log = false;
+      updateServiceStatus();
+    }
   });
 
   $$('#cleanup form').forEach(f => f.addEventListener('submit', async (e)=>{
@@ -63,6 +104,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('?action=cleanup', { method:'POST', body:fd });
     const js = await res.json(); if (js.ok) alert('Nettoyé'); else alert(js.error||'Erreur');
   }));
+
+  updateServiceStatus();
 
   function step(k){
     $$('[data-status]').forEach(b=>b.classList.remove('badge--ok'));

--- a/templates/pages/home_inner.php
+++ b/templates/pages/home_inner.php
@@ -64,3 +64,17 @@
   <button class="btn" id="btn-log-clear">Vider log</button>
 </div>
 <pre class="log" id="log"></pre>
+<div class="card" style="margin-top:10px;">
+  <h4>Bilan rapide</h4>
+  <ul id="service-status" class="text-muted" style="margin-top:6px;">
+    <li>Upload: en attente</li>
+    <li>Scan DOCX: en attente</li>
+    <li>Conversion HTML: en attente</li>
+    <li>Extraction: en attente</li>
+    <li>Log debug: en attente</li>
+  </ul>
+
+  <h4 style="margin-top:10px;">Log brut</h4>
+  <pre class="log" id="raw-log">Aucun log brut chargé.</pre>
+</div>
+


### PR DESCRIPTION
### Motivation
- Fournir dans la page de debug un retour visuel rapide sur l’état des services (upload, scan DOCX, conversion HTML, extraction, log) et un accès au log brut pour faciliter l’investigation.

### Description
- Ajout d’un bloc UI « Bilan rapide » et d’une zone « Log brut » dans `templates/pages/home_inner.php` (`#service-status` et `#raw-log`).
- Ajout d’un état applicatif `serviceStates` et de la fonction `updateServiceStatus()` dans `public/assets/app.js` pour afficher `actif/inactif` pour chaque service.
- Mise à jour des handlers front (upload, scan, conversion, extraction, lecture/vidage du log) pour basculer les états correspondants et remplir `#raw-log` lors de la lecture/vidage du log.
- Appel initial de `updateServiceStatus()` pour rendre l’état cohérent au chargement de la page.

### Testing
- Vérification syntaxique PHP avec `php -l templates/pages/home_inner.php` a réussi (pas d’erreur de syntaxe). 
- Vérification syntaxique JS avec `node --check public/assets/app.js` a réussi (pas d’erreur).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0990e62030832eb44fb250d5938870)